### PR TITLE
test: `changedCookieHeaderValue` and `expiredCookieHeaderValue`

### DIFF
--- a/src/utils/cookie/changedCookieHeaderValue/changedCookieHeaderValue.test.ts
+++ b/src/utils/cookie/changedCookieHeaderValue/changedCookieHeaderValue.test.ts
@@ -1,0 +1,39 @@
+import { changedCookieHeaderValue } from './changedCookieHeaderValue'
+
+const cookieName = 'my-testCookie'
+const cookieValue = 'abc-123&;/abc-_'
+
+describe('changedCookieHeaderValue', () => {
+  it('should not contain the expiration attribute', () => {
+    expect(changedCookieHeaderValue(cookieName, cookieValue)).not.toContain(
+      '; expires',
+    )
+  })
+  it('has a value', () => {
+    expect(changedCookieHeaderValue(cookieName, cookieValue)).toMatch(
+      new RegExp(`^${cookieName}=.+;`),
+    )
+  })
+  it.todo('url encodes the value')
+  it('is secure', () => {
+    expect(changedCookieHeaderValue(cookieName, cookieValue)).toContain(
+      '; secure',
+    )
+  })
+  it("has the attribute 'samesite=none'", () => {
+    // TODO is this attribute really necessary?
+    expect(changedCookieHeaderValue(cookieName, cookieValue)).toContain(
+      '; samesite=none',
+    )
+  })
+  it("is visible on all paths ('path=/')", () => {
+    expect(changedCookieHeaderValue(cookieName, cookieValue)).toContain(
+      '; path=/',
+    )
+  })
+  it("is 'httponly'", () => {
+    expect(changedCookieHeaderValue(cookieName, cookieValue)).toContain(
+      '; httponly',
+    )
+  })
+})

--- a/src/utils/cookie/expiredCookieHeaderValue/expiredCookieHeaderValue.test.ts
+++ b/src/utils/cookie/expiredCookieHeaderValue/expiredCookieHeaderValue.test.ts
@@ -18,7 +18,6 @@ describe('expiredCookieHeaderValue', () => {
     expect(expiredCookieHeaderValue(cookieName)).toContain('; secure')
   })
   it("has the attribute 'samesite=none'", () => {
-    // TODO is this attribute really necessary?
     expect(expiredCookieHeaderValue(cookieName)).toContain('; samesite=none')
   })
   it("is visible on all paths ('path=/')", () => {

--- a/src/utils/cookie/expiredCookieHeaderValue/expiredCookieHeaderValue.test.ts
+++ b/src/utils/cookie/expiredCookieHeaderValue/expiredCookieHeaderValue.test.ts
@@ -1,0 +1,30 @@
+import { expiredCookieHeaderValue } from './expiredCookieHeaderValue'
+
+const cookieName = 'my-cookieName'
+
+describe('expiredCookieHeaderValue', () => {
+  it('should contain the expiration attribute', () => {
+    expect(expiredCookieHeaderValue(cookieName)).toContain('; expires')
+  })
+  test('that the expiration date should be the start of Unix epoch', () => {
+    expect(expiredCookieHeaderValue(cookieName)).toContain(
+      `; expires=${new Date(0).toUTCString()}`,
+    )
+  })
+  it('has no value', () => {
+    expect(expiredCookieHeaderValue(cookieName)).toContain(`${cookieName}=""`)
+  })
+  it('is secure', () => {
+    expect(expiredCookieHeaderValue(cookieName)).toContain('; secure')
+  })
+  it("has the attribute 'samesite=none'", () => {
+    // TODO is this attribute really necessary?
+    expect(expiredCookieHeaderValue(cookieName)).toContain('; samesite=none')
+  })
+  it("is visible on all paths ('path=/')", () => {
+    expect(expiredCookieHeaderValue(cookieName)).toContain('; path=/')
+  })
+  it("is 'httponly'", () => {
+    expect(expiredCookieHeaderValue(cookieName)).toContain('; httponly')
+  })
+})


### PR DESCRIPTION
Test for `changedCookieHeaderValue` and `expiredCookieHeaderValue`

These functions return the value of the Set-Cookie header for when you want to update the value (`changedCookieHeaderValue`) and when you want to expire the cookie (`expiredCookieHeaderValue`)