### PR TITLE
ci: use GitHub releases to publish to NPM and adding job for type checking to workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,7 @@
 
 name: Node.js Package
 
-# TODO  create github release when merging to main https://github.com/actions/create-release
-
 on:
-  release:
-    types: [created]
   push:
 
 jobs:
@@ -20,16 +16,16 @@ jobs:
         with:
           node-version: 16
           cache: 'yarn'
-      - run: yarn install --frozen-lockfile
-      - run: yarn test
-      - run: yarn build
-      - uses: actions/upload-artifact@master
-        with:
-          name: dist
-          path: dist/
+      - name: Install
+        run: yarn install --frozen-lockfile
+      - name: Check types
+        run: yarn check:types
+      - name: Test
+        run: yarn test
+      - name: Build
+        run: yarn build
   publish-npm:
-    name: Publish to NPM
-    needs: build
+    name: Dry-run Publish to NPM
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -38,16 +34,11 @@ jobs:
           node-version: 16
           cache: 'yarn'
           registry-url: https://registry.npmjs.org/
-      - uses: actions/download-artifact@master
-        with:
-          name: dist
-          path: dist/
-      - run: yarn install --frozen-lockfile
-      - if: github.ref != 'refs/heads/main'
+      - name: Install
+        run: yarn install --frozen-lockfile
+      - name: Build
+        run: yarn build
+      - name: Dry-run publish to NPM
         run: npm publish --access public --dry-run
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - if: github.ref == 'refs/heads/main'
-        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,21 +24,3 @@ jobs:
         run: yarn test
       - name: Build
         run: yarn build
-  publish-npm:
-    name: Dry-run Publish to NPM
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: 'yarn'
-          registry-url: https://registry.npmjs.org/
-      - name: Install
-        run: yarn install --frozen-lockfile
-      - name: Build
-        run: yarn build
-      - name: Dry-run publish to NPM
-        run: npm publish --access public --dry-run
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/npm-publish-library.yml
+++ b/.github/workflows/npm-publish-library.yml
@@ -1,0 +1,27 @@
+name: Publish library to NPM
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish-npm:
+    if: startsWith(github.event.release.name, '@storyblok/app-extension-auth@')
+    name: Publish library to NPM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'yarn'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install
+        run: yarn install --immutable
+      - name: Build
+        run: yarn build
+      - name: Publish to NPM
+        run: npm publish --access public --tag alpha
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lint": "eslint .",
     "build": "rollup -c",
     "start": "rollup -c -w",
+    "check:types": "tsc --noEmit",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
Issue: EXT-1516

- Changing to use GitHub releases to publish to NPM.
- Adding job for type checking to workflow