### PR TITLE
feat: Support for US Region

### DIFF
--- a/src/storyblok-auth-api/handle-requests/handleCallback/fetchAppSession.ts
+++ b/src/storyblok-auth-api/handle-requests/handleCallback/fetchAppSession.ts
@@ -9,13 +9,14 @@ export const fetchAppSession = async (
   params: AuthHandlerParams,
   requestParams: {
     url: string
+    spaceId: number
     codeVerifier: string
     state: string
   },
 ): Promise<AppSession | undefined> => {
-  const { codeVerifier, state, url } = requestParams
+  const { spaceId, codeVerifier, state, url } = requestParams
 
-  const client = openidClient(params)
+  const client = openidClient(params, spaceId)
 
   const callbackParams = client.callbackParams(url)
   const tokenSet = await client.oauthCallback(

--- a/src/storyblok-auth-api/handle-requests/handleCallback/handleCallbackRequest.ts
+++ b/src/storyblok-auth-api/handle-requests/handleCallback/handleCallbackRequest.ts
@@ -8,6 +8,7 @@ import {
 } from '../callbackCookie'
 import { CookieElement } from '../../ResponseElement'
 import { AuthHandlerParams } from '../../AuthHandlerParams'
+import { spaceIdFromUrl } from './spaceIdFromUrl'
 import { HandleAuthRequest } from '../HandleAuthRequest'
 import { fetchAppSession } from './fetchAppSession'
 
@@ -22,6 +23,15 @@ export const handleCallbackRequest: HandleAuthRequest<{
   getCookie: GetCookie
 }> = async ({ params, url, getCookie }) => {
   try {
+    const spaceId = spaceIdFromUrl(url)
+    if (!spaceId) {
+      return {
+        type: 'error',
+        message:
+          'The callback URL is missing the following parameter: space_id',
+      }
+    }
+
     const callbackCookie = getCallbackCookieData(params.clientSecret, getCookie)
     if (!callbackCookie) {
       return {
@@ -33,6 +43,7 @@ export const handleCallbackRequest: HandleAuthRequest<{
 
     const { codeVerifier, state, returnTo } = callbackCookie
     const appSession = await fetchAppSession(params, {
+      spaceId,
       codeVerifier,
       state,
       url,

--- a/src/storyblok-auth-api/handle-requests/handleSignIn/handleSignInRequest.ts
+++ b/src/storyblok-auth-api/handle-requests/handleSignIn/handleSignInRequest.ts
@@ -14,7 +14,7 @@ export const handleSignInRequest: HandleAuthRequest<{
 
   try {
     // TODO get rid of dummy spaceId
-    const redirectTo = openidClient(params).authorizationUrl({
+    const redirectTo = openidClient(params, 0).authorizationUrl({
       scope: params.scope.join(' '),
       code_challenge,
       state,

--- a/src/storyblok-auth-api/handle-requests/handleSignIn/handleSignInRequest.ts
+++ b/src/storyblok-auth-api/handle-requests/handleSignIn/handleSignInRequest.ts
@@ -13,8 +13,7 @@ export const handleSignInRequest: HandleAuthRequest<{
   const code_challenge = generators.codeChallenge(code_verifier)
 
   try {
-    // TODO get rid of dummy spaceId
-    const redirectTo = openidClient(params, 0).authorizationUrl({
+    const redirectTo = openidClient(params).authorizationUrl({
       scope: params.scope.join(' '),
       code_challenge,
       state,

--- a/src/storyblok-auth-api/handle-requests/oauthApiBaseUrl.ts
+++ b/src/storyblok-auth-api/handle-requests/oauthApiBaseUrl.ts
@@ -1,1 +1,20 @@
-export const oauthApiBaseUrl = 'https://app.storyblok.com/oauth'
+const isEuSpace = (spaceId: number) => spaceId >= 0 && spaceId < 1000000
+const isUsSpace = (spaceId: number) => spaceId >= 1000000 && spaceId < 2000000
+
+/**
+ * Given a spaceId, returns the API base url for authenticating with oauth
+ * @param spaceId
+ */
+export const oauthApiBaseUrl = (spaceId: number) => {
+  if (isEuSpace(spaceId)) {
+    return 'https://app.storyblok.com/oauth'
+  }
+  if (isUsSpace(spaceId)) {
+    return 'https://app.storyblok.com/v1_us/oauth'
+  } else {
+    // TODO type-safe error handling
+    throw new Error(
+      'The spaceId belongs to an unrecognized region. Supported regions are: EU, US. Please upgrade @storyblok/app-extension-auth to a newer version.',
+    )
+  }
+}

--- a/src/storyblok-auth-api/handle-requests/openidClient.ts
+++ b/src/storyblok-auth-api/handle-requests/openidClient.ts
@@ -8,16 +8,23 @@ export type CreateOpenIdClient = (
     AuthHandlerParams,
     'clientId' | 'clientSecret' | 'baseUrl' | 'endpointPrefix'
   >,
-  spaceId: number,
+  spaceId?: number,
 ) => BaseClient
 
 export const openidClient: CreateOpenIdClient = (params, spaceId) => {
   const { clientId, clientSecret } = params
   const { Client } = new Issuer({
     issuer: 'storyblok',
-    authorization_endpoint: `${oauthApiBaseUrl(spaceId)}/authorize`,
-    token_endpoint: `${oauthApiBaseUrl(spaceId)}/token`,
-    userinfo_endpoint: `${oauthApiBaseUrl(spaceId)}/user_info`,
+    // This is always the eu endpoint, even for other regions
+    authorization_endpoint: `${oauthApiBaseUrl(0)}/authorize`,
+    token_endpoint:
+      typeof spaceId !== 'undefined'
+        ? `${oauthApiBaseUrl(spaceId)}/token`
+        : undefined,
+    userinfo_endpoint:
+      typeof spaceId !== 'undefined'
+        ? `${oauthApiBaseUrl(spaceId)}/user_info`
+        : undefined,
   })
   return new Client({
     token_endpoint_auth_method: 'client_secret_post',

--- a/src/storyblok-auth-api/handle-requests/openidClient.ts
+++ b/src/storyblok-auth-api/handle-requests/openidClient.ts
@@ -8,15 +8,16 @@ export type CreateOpenIdClient = (
     AuthHandlerParams,
     'clientId' | 'clientSecret' | 'baseUrl' | 'endpointPrefix'
   >,
+  spaceId: number,
 ) => BaseClient
 
-export const openidClient: CreateOpenIdClient = (params) => {
+export const openidClient: CreateOpenIdClient = (params, spaceId) => {
   const { clientId, clientSecret } = params
   const { Client } = new Issuer({
     issuer: 'storyblok',
-    authorization_endpoint: `${oauthApiBaseUrl}/authorize`,
-    token_endpoint: `${oauthApiBaseUrl}/token`,
-    userinfo_endpoint: `${oauthApiBaseUrl}/user_info`,
+    authorization_endpoint: `${oauthApiBaseUrl(spaceId)}/authorize`,
+    token_endpoint: `${oauthApiBaseUrl(spaceId)}/token`,
+    userinfo_endpoint: `${oauthApiBaseUrl(spaceId)}/user_info`,
   })
   return new Client({
     token_endpoint_auth_method: 'client_secret_post',


### PR DESCRIPTION
## What

Support for authentication in the US region.

The openId client is now parameterized with the spaceId, meaning that different URLs will be used to retrive the access token and the user_info.

## How to test

Run the Next.js template locally and open the app on an EU space:

<img width="1512" alt="image" src="https://github.com/storyblok/app-extension-auth/assets/14206504/ce41a8d9-99a6-417c-9300-625bdf999346">

Open on a US space:

<img width="1512" alt="image" src="https://github.com/storyblok/app-extension-auth/assets/14206504/df206293-99b3-4b72-92b2-8a9fdddd03b7">

This means that the user was authenticated. The reason why the stories are not retrieved is that the Nextjs starter also has to use different endpoints depending on the spaceId, and for that reason, the request fails. But that is an issue with the template.