### PR TITLE
fix: refreshing token with the correct regional API

### DIFF
--- a/src/session/refreshStoredAppSession.ts
+++ b/src/session/refreshStoredAppSession.ts
@@ -40,9 +40,9 @@ export const refreshStoredAppSession: Refresh = async (
   }
 
   // should refresh
-  const newAppSession = await refreshAppSession(refreshToken(params))(
-    currentAppSession,
-  )
+  const newAppSession = await refreshAppSession(
+    refreshToken(params, currentAppSession.region),
+  )(currentAppSession)
 
   if (!newAppSession) {
     // Refresh failed -> user becomes unauthenticated

--- a/src/storyblok-auth-api/refreshToken.ts
+++ b/src/storyblok-auth-api/refreshToken.ts
@@ -29,7 +29,6 @@ export const refreshToken =
   (params: RefreshTokenWithFetchParams, region: Region): RefreshToken =>
   async (refreshToken: string) => {
     try {
-      // TODO dynamic region
       const tokenSet = await openidClient(params, region).refresh(refreshToken)
       if (!isRefreshTokenResponse(tokenSet)) {
         return new Error(

--- a/src/storyblok-auth-api/refreshToken.ts
+++ b/src/storyblok-auth-api/refreshToken.ts
@@ -1,6 +1,7 @@
 import { hasKey } from '../utils'
 import { AuthHandlerParams } from './AuthHandlerParams'
 import { openidClient } from './handle-requests/openidClient'
+import { Region } from '../session'
 
 export type RefreshTokenWithFetchParams = Pick<
   AuthHandlerParams,
@@ -22,13 +23,14 @@ const isRefreshTokenResponse = (data: unknown): data is RefreshTokenResponse =>
 /**
  * Uses a refresh token to request a new accessToken
  * @param params
+ * @param region
  */
 export const refreshToken =
-  (params: RefreshTokenWithFetchParams): RefreshToken =>
+  (params: RefreshTokenWithFetchParams, region: Region): RefreshToken =>
   async (refreshToken: string) => {
     try {
       // TODO dynamic region
-      const tokenSet = await openidClient(params, 'eu').refresh(refreshToken)
+      const tokenSet = await openidClient(params, region).refresh(refreshToken)
       if (!isRefreshTokenResponse(tokenSet)) {
         return new Error(
           'Unexpected format: the server returned an object with an unexpected format',


### PR DESCRIPTION
Issue: EXT-1581

Refreshing token with the correct regional API. 

For the US region, a different API URL is used, thus the `region` property in the `AppSession` must be passed to the `openidClient` function call that is done when the access token is refreshed. 