### PR TITLE
chore: revert restriction on yarn version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "test": "jest"
   },
   "engines": {
-    "yarn": "^3.2.4",
     "node": ">=14.21.3"
   },
   "packageManager": "yarn@3.2.4",


### PR DESCRIPTION
## What?

In https://github.com/storyblok/app-extension-auth/pull/11, we enforced yarn v3, but we don't need to do the same to our users. 

## Why?

Whatever yarn version they use, they should be able to use this library. It actually doesn't matter to them.