### PR TITLE
fix: add custom role type and validation

### DIFF
--- a/src/storyblok-auth-api/handle-requests/handleCallback/fetchAppSession.ts
+++ b/src/storyblok-auth-api/handle-requests/handleCallback/fetchAppSession.ts
@@ -3,7 +3,7 @@ import { AppSession, Region } from '../../../session'
 import { openidClient } from '../openidClient'
 import { redirectUri } from '../redirectUri'
 import { isTokenSet } from './isTokenSet'
-import { isUserInfo } from '../../user-info'
+import { isStoryblokRole, isUserInfo, Role } from '../../user-info'
 
 export const fetchAppSession = async (
   params: AuthHandlerParams,
@@ -41,11 +41,19 @@ export const fetchAppSession = async (
     accessToken: tokenSet.access_token,
     expiresAt: Date.now() + tokenSet.expires_in * 1000,
     appClientId: params.clientId,
-    roles: userInfo.roles.map((role) => role.name),
+    roles: userInfo.roles.map((role) => getRoleName(role)),
     spaceId: userInfo.space.id,
     spaceName: userInfo.space.name,
     userId: userInfo.user.id,
     userName: userInfo.user.friendly_name,
     region,
   }
+}
+
+const getRoleName = (role: Role): string => {
+  if (isStoryblokRole(role)) {
+    return role.name
+  }
+
+  return role.role
 }

--- a/src/storyblok-auth-api/user-info/Role/Role.ts
+++ b/src/storyblok-auth-api/user-info/Role/Role.ts
@@ -1,3 +1,22 @@
-export type Role = {
+export type Role = StoryblokRole | CustomRole
+
+export type StoryblokRole = {
   name: string
+}
+
+export type CustomRole = {
+  id: number
+  resolved_allowed_paths: string[]
+  allowed_paths: number[]
+  field_permissions: string[]
+  readonly_field_permissions: string[]
+  permissions: string[]
+  role: string
+  subtitle: string | null
+  datasource_ids: number[]
+  component_ids: number[]
+  branch_ids: number[]
+  allowed_languages: string[]
+  asset_folder_ids: number[]
+  ext_id: string | null
 }

--- a/src/storyblok-auth-api/user-info/Role/isRole.ts
+++ b/src/storyblok-auth-api/user-info/Role/isRole.ts
@@ -1,5 +1,14 @@
 import { hasKey } from '../../../utils'
-import { Role } from './Role'
+import { CustomRole, Role, StoryblokRole } from './Role'
 
 export const isRole = (obj: unknown): obj is Role =>
+  isStoryblokRole(obj) || isCustomRole(obj)
+
+export const isStoryblokRole = (obj: unknown): obj is StoryblokRole =>
   hasKey(obj, 'name') && typeof obj.name === 'string'
+
+export const isCustomRole = (obj: unknown): obj is CustomRole =>
+  hasKey(obj, 'id') &&
+  typeof obj.id === 'number' &&
+  hasKey(obj, 'role') &&
+  typeof obj.role === 'string'


### PR DESCRIPTION
Issue:
[EXT-2001](https://storyblok.atlassian.net/browse/EXT-2001)

## What?
Users with custom roles are being redirected to the errorCallback page. This is an unexpected behavior.

Here a reference for better understaning: 

1. Response from /oauth/user_info with the backed-in storyblok role (admin or editor)
```
{
    "user": {
        "id": 123,
        "friendly_name": "Bibiana"
    },
    "space": {
        "id": 1234,
        "name": "Test"
    },
    "roles": [
        {
            "name": "admin"
        }
    ]
}
```

2. Response from /oauth/user_info with a custom role user:
```
{
    "user": {
        "id": 123,
        "friendly_name": "Bibiana"
    },
    "space": {
        "id": 1234,
        "name": "Test"
    },
    "roles": [
        {
            "id": 1,
            "resolved_allowed_paths": [],
            "allowed_paths": [],
            "field_permissions": [],
            "readonly_field_permissions": [],
            "permissions": [],
            "role": "Developer",
            "subtitle": null,
            "datasource_ids": [],
            "component_ids": [],
            "branch_ids": [],
            "allowed_languages": [],
            "asset_folder_ids": [],
            "ext_id": null
        },
    ],
}
```

The problem happens when validating the role object: 
```
const isRole = (obj) => 'name' in obj && typeof obj.name === 'string'
```

As the custom role has no `name`property this validation fails.


[Support Ticket: EXT-2001](https://storyblok.atlassian.net/browse/EXT-2001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

[EXT-2001]: https://storyblok.atlassian.net/browse/EXT-2001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ