### PR TITLE
fix: phaseout google chrome and edge partitioned cookie

### DIFF
--- a/src/utils/cookie/changedCookieHeaderValue/changedCookieHeaderValue.ts
+++ b/src/utils/cookie/changedCookieHeaderValue/changedCookieHeaderValue.ts
@@ -5,4 +5,4 @@
  * @param value
  */
 export const changedCookieHeaderValue = (name: string, value: string) =>
-  `${name}=${value}; path=/; samesite=none; secure; httponly`
+  `${name}=${value}; path=/; samesite=none; secure; httponly; partitioned;`

--- a/src/utils/cookie/expiredCookieHeaderValue/expiredCookieHeaderValue.ts
+++ b/src/utils/cookie/expiredCookieHeaderValue/expiredCookieHeaderValue.ts
@@ -1,2 +1,2 @@
 export const expiredCookieHeaderValue = (name: string) =>
-  `${name}=""; path=/; samesite=none; secure; httponly; expires=Thu, 01 Jan 1970 00:00:00 GMT`
+  `${name}=""; path=/; samesite=none; secure; httponly; expires=Thu, 01 Jan 1970 00:00:00 GMT; partitioned;`


### PR DESCRIPTION
Issue:

## What?
As the Google Chrome third-party cookie phaseout approaches, we need to add a way for our customers to avoid space and tool plugins from breaking. One solution includes extending the cookie value to `partitioned` as described [here](https://developers.google.com/privacy-sandbox/3pcd/chips). 

