### PR TITLE
feat: expire cookie after 1 week

### DIFF
--- a/src/session-adapters/cookieAdapter.ts
+++ b/src/session-adapters/cookieAdapter.ts
@@ -36,8 +36,16 @@ export const cookieAdapter: Adapter = {
   },
 
   setItem: ({ res, spaceId, userId, key, value }) => {
+    const expires = new Date()
+    expires.setDate(expires.getDate() + 7)
+
     const signedData = jwt.sign({ data: value }, clientSecret)
-    setCookie(res, createScopedKey({ spaceId, userId, key }), signedData)
+    setCookie(
+      res,
+      createScopedKey({ spaceId, userId, key }),
+      signedData,
+      expires,
+    )
     return true
   },
 

--- a/src/utils/cookie/changedCookieHeaderValue/changedCookieHeaderValue.ts
+++ b/src/utils/cookie/changedCookieHeaderValue/changedCookieHeaderValue.ts
@@ -4,5 +4,20 @@
  * @param name
  * @param value
  */
-export const changedCookieHeaderValue = (name: string, value: string) =>
-  `${name}=${value}; path=/; samesite=none; secure; httponly; partitioned;`
+export const changedCookieHeaderValue = (
+  name: string,
+  value: string,
+  expires?: Date,
+) => {
+  return [
+    `${name}=${value}`,
+    'path=/',
+    expires ? `Expires=${expires.toISOString()}; ` : undefined,
+    'samesite=none',
+    'secure',
+    'httponly',
+    'partitioned',
+  ]
+    .filter(Boolean)
+    .join('; ')
+}

--- a/src/utils/cookie/setCookie/setCookie.ts
+++ b/src/utils/cookie/setCookie/setCookie.ts
@@ -24,9 +24,10 @@ const withCookie = (
   headers: string[],
   name: string,
   value: string,
+  expires?: Date,
 ): string[] => [
   ...headers.filter((header) => !header.startsWith(`${name}=`)),
-  changedCookieHeaderValue(name, value),
+  changedCookieHeaderValue(name, value, expires),
 ]
 
 const withExpiredCookie = (headers: string[], name: string): string[] => [
@@ -38,8 +39,12 @@ export const setCookie = (
   res: http.ServerResponse,
   name: string,
   value: string,
+  expires?: Date,
 ): void =>
-  void res.setHeader('Set-Cookie', withCookie(cookieHeaders(res), name, value))
+  void res.setHeader(
+    'Set-Cookie',
+    withCookie(cookieHeaders(res), name, value, expires),
+  )
 
 export const expireCookie = (res: http.ServerResponse, name: string) =>
   void res.setHeader('Set-Cookie', withExpiredCookie(cookieHeaders(res), name))


### PR DESCRIPTION
## What?

This PR sets a 1-week expiry for the cookie.

## Why?

Currently the cookie doesn't have any expiry. It means the cookie is treated as session cookie. It expires only when the user closes the browser, not the tab. Then if the user keeps the browser open for a long time, the cookie won't expire. However it's okay, because within the cookie value, we've written the actual expiration date for the access token, and we can refresh the token. However, it's better to clean up the token once in a while, to avoid having stale values in the browser. That's why we explicitly set 1-week expiry.