### PR TITLE
feat: add `inferSessionQuery`

### DIFF
--- a/src/session/sessionStore.ts
+++ b/src/session/sessionStore.ts
@@ -1,7 +1,12 @@
-import { AppSessionCookieStoreFactory, AppSessionStore } from './types'
+import {
+  AppSessionCookieStoreFactory,
+  AppSessionQuery,
+  AppSessionStore,
+} from './types'
 import { refreshStoredAppSession } from './refreshStoredAppSession'
 import { cookieAdapter } from '../session-adapters/cookieAdapter'
 import { createInternalAdapter } from '../session-adapters/internalAdapter'
+import { IncomingMessage } from 'http'
 
 export const getSessionStore: AppSessionCookieStoreFactory =
   (params) =>
@@ -34,3 +39,34 @@ export const getSessionStore: AppSessionCookieStoreFactory =
         }),
     }
   }
+
+export const inferSessionQuery = (
+  req: IncomingMessage,
+): AppSessionQuery | undefined => {
+  if (!req.url) {
+    return
+  }
+  const url = new URL(req.url)
+  const spaceId = url.searchParams.get('space_id')
+  const userId = url.searchParams.get('user_id')
+  if (spaceId && userId) {
+    return {
+      spaceId,
+      userId,
+    }
+  }
+
+  if (req.headers.referer) {
+    const refererUrl = new URL(req.url)
+    const spaceId = refererUrl.searchParams.get('space_id')
+    const userId = refererUrl.searchParams.get('user_id')
+    if (spaceId && userId) {
+      return {
+        spaceId,
+        userId,
+      }
+    }
+  }
+
+  return undefined
+}

--- a/src/storyblok-auth-api/handle-requests/handleCallback/handleCallbackRequest.ts
+++ b/src/storyblok-auth-api/handle-requests/handleCallback/handleCallbackRequest.ts
@@ -1,4 +1,3 @@
-import { AppSession } from '../../../session'
 import { appendQueryParams } from '../../../utils/query-params/append-query-params'
 import { AuthHandlerParams } from '../../AuthHandlerParams'
 import { regionFromUrl } from './spaceIdFromUrl'
@@ -6,10 +5,10 @@ import { HandleAuthRequest } from '../HandleAuthRequest'
 import { fetchAppSession } from './fetchAppSession'
 import { InternalAdapter } from '../../../session-adapters/internalAdapter'
 
-export type AppSessionQueryParams = Record<
-  keyof Pick<AppSession, 'spaceId' | 'userId'>,
-  string
->
+export type AppSessionQueryParams = {
+  space_id: string
+  user_id: string
+}
 
 export const handleCallbackRequest: HandleAuthRequest<{
   params: AuthHandlerParams
@@ -53,8 +52,8 @@ export const handleCallbackRequest: HandleAuthRequest<{
     const spaceId = appSession.spaceId.toString()
     const userId = appSession.userId.toString()
     const queryParams: AppSessionQueryParams = {
-      spaceId,
-      userId,
+      space_id: spaceId,
+      user_id: userId,
     }
     const redirectTo = appendQueryParams(returnTo, queryParams)
 


### PR DESCRIPTION
## What?

This PR adds `inferSessionQuery` method which makes the starter projects simpler.

## Why?

We need to infer the current space_id and user_id, and it requires some work. It's better to provide it from this library instead of pushing it to the user land.
