### PR TITLE
Pass client secret to cookie adapter

### DIFF
--- a/src/session-adapters/createCookieAdapter.ts
+++ b/src/session-adapters/createCookieAdapter.ts
@@ -3,15 +3,17 @@ import jwt from 'jsonwebtoken'
 import { Adapter } from './publicAdapter'
 import { isAppSession } from '../session'
 
-const clientSecret = process.env['CLIENT_SECRET'] || ''
 const defaultSessionKey = 'sb.auth'
+const defaultClientSecret = process.env['CLIENT_SECRET'] || ''
 
 type CreateCookieAdapter = (params?: {
   sessionKey?: string | undefined
+  clientSecret?: string | undefined
 }) => Adapter
 
 export const createCookieAdapter: CreateCookieAdapter = (params) => {
   const key = params?.sessionKey ?? defaultSessionKey
+  const clientSecret = params?.clientSecret ?? defaultClientSecret
 
   const adapter: Adapter = {
     getSession: ({ req, spaceId, userId }) => {

--- a/src/session/sessionStore.ts
+++ b/src/session/sessionStore.ts
@@ -16,7 +16,10 @@ export const getSessionStore: AppSessionCookieStoreFactory =
       params,
       req: requestParams.req,
       res: requestParams.res,
-      adapter: createCookieAdapter({ sessionKey: params.sessionKey }),
+      adapter: createCookieAdapter({
+        sessionKey: params.sessionKey,
+        clientSecret: params.clientSecret,
+      }),
     })
 
     return {

--- a/src/storyblok-auth-api/auth-handler.ts
+++ b/src/storyblok-auth-api/auth-handler.ts
@@ -22,7 +22,10 @@ export const authHandler = (
       params,
       req,
       res,
-      adapter: createCookieAdapter({ sessionKey: params.sessionKey }),
+      adapter: createCookieAdapter({
+        sessionKey: params.sessionKey,
+        clientSecret: params.clientSecret,
+      }),
     })
 
     const responseElement = await handleAnyRequest({


### PR DESCRIPTION
Issue: https://github.com/storyblok/app-extension-auth/issues/47

This fixes issue #47 with incorrent sourcing of client secret in cookie adapter.