### PR TITLE
Replace CLIENT_SECRET env var

### DIFF
--- a/src/session-adapters/createCookieAdapter.ts
+++ b/src/session-adapters/createCookieAdapter.ts
@@ -3,7 +3,6 @@ import jwt from 'jsonwebtoken'
 import { Adapter } from './publicAdapter'
 import { isAppSession } from '../session'
 
-const clientSecret = process.env['CLIENT_SECRET'] || ''
 const defaultSessionKey = 'sb.auth'
 
 type CreateCookieAdapter = (params?: {
@@ -21,7 +20,7 @@ export const createCookieAdapter: CreateCookieAdapter = (params) => {
         return undefined
       }
 
-      const verifiedData = verifyData(clientSecret, cookie)
+      const verifiedData = verifyData(params.clientSecret, cookie)
 
       if (!isAppSession(verifiedData)) {
         return undefined
@@ -33,7 +32,7 @@ export const createCookieAdapter: CreateCookieAdapter = (params) => {
     setSession: ({ res, spaceId, userId, session }) => {
       const expires = createExpirationDate(7)
 
-      const signedData = jwt.sign({ data: session }, clientSecret)
+      const signedData = jwt.sign({ data: session }, params.clientSecret)
 
       setCookie(
         res,


### PR DESCRIPTION
Issue:

## What?
I used the env var name suggested by the README: APP_CLIENT_SECRET. This resulted in the error `Setting the session failed:  Error: secretOrPrivateKey must have a value`. After some source diving I found out that the library request the CLIENT_SECRET env var to be set.

## Why?
Just read the value from the params object. 