### PR TITLE
chore: update the region-helper package to 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "packageManager": "pnpm@10.8.0",
   "dependencies": {
-    "@storyblok/region-helper": "^1.2.0",
+    "@storyblok/region-helper": "^1.3.0",
     "jsonwebtoken": "^9.0.0",
     "openid-client": "^5.7.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@storyblok/region-helper':
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^1.3.0
+        version: 1.3.0
       jsonwebtoken:
         specifier: ^9.0.0
         version: 9.0.2
@@ -674,8 +674,8 @@ packages:
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
-  '@storyblok/region-helper@1.2.0':
-    resolution: {integrity: sha512-Ew6okkK7vQvkk/jdjaM7f6szJXYtcBmPJXhl3zzh/rW9QdAaHKOodiIbvdkpvkcOrSNmUpXcx5d2gxYL5HRIzg==}
+  '@storyblok/region-helper@1.3.0':
+    resolution: {integrity: sha512-yzjeUApGbGGsSLdnFLWN3U53YgOslVuwgak/bZZ5bT0pFlseVcb9HNd9WgzgvWHqXrAW55fXayisQ//qnsCxYw==}
 
   '@tootallnate/once@2.0.0':
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
@@ -3517,7 +3517,7 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@storyblok/region-helper@1.2.0': {}
+  '@storyblok/region-helper@1.3.0': {}
 
   '@tootallnate/once@2.0.0': {}
 


### PR DESCRIPTION
Issue: SHAPE-10699

## What?

It updates the version of the [region-helper ](https://www.npmjs.com/package/@storyblok/region-helper) package to use its [latest version](https://github.com/storyblok/region-helper/releases/tag/v1.3.0), which supports the [new UUID approach](https://www.storyblok.com/mp/upcoming-update-to-the-id-format-of-spaces-and-entities#space-ids) for spaceIDs in CN environments (although the backend still doesn't fully support it).